### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set_target_properties (CanReceiver-someip PROPERTIES INTERFACE_LINK_LIBRARY "")
 
 ### INSTALL ###
 
-file(GLOB_RECURSE HEADER_FILES "src-gen/core/v${MAJOR_VERSION}/${APP_PACKAGE_NAME}/*Proxy.hpp")
+file(GLOB_RECURSE HEADER_FILES "src-gen/core/v${MAJOR_VERSION}/${APP_PACKAGE_NAME}/*Proxy*.hpp")
 foreach(HEADER ${HEADER_FILES})
     # Get absolute path of header files.
     get_filename_component(HEADER_ABS_PATH ${HEADER} ABSOLUTE)


### PR DESCRIPTION
*Proxy.hpp only exports {appname}Proxy.hpp but I found out {appname}Proxybase.hpp is also required to build proxy.
so the rule is now *Proxy*.hpp